### PR TITLE
Perf: 변경 케이크 모아보기 썸네일 이미지로 변경

### DIFF
--- a/src/main/java/com/project/makecake/controller/backoffice/BackOfficeController.java
+++ b/src/main/java/com/project/makecake/controller/backoffice/BackOfficeController.java
@@ -30,11 +30,11 @@ public class BackOfficeController {
         return backOfficeService.boSearchStoreId(requestDto);
     }
 
-    @GetMapping("/api/backOffice/cake/thumbnail-img")
-    public void addCakeThumbNailImg(
-            @RequestParam int page
-    ) throws IOException {
-        backOfficeService.addCakeThumbNailImg(page);
-    }
+//    @GetMapping("/api/backOffice/cake/thumbnail-img")
+//    public void addCakeThumbNailImg(
+//            @RequestParam int page
+//    ) throws IOException {
+//        backOfficeService.addCakeThumbNailImg(page);
+//    }
 
 }

--- a/src/main/java/com/project/makecake/dto/cake/CakeResponseDto.java
+++ b/src/main/java/com/project/makecake/dto/cake/CakeResponseDto.java
@@ -13,9 +13,9 @@ public class CakeResponseDto {
     private boolean myLike;
 
     @Builder
-    public CakeResponseDto(Cake cake, boolean myLike) {
+    public CakeResponseDto(Cake cake, boolean myLike, String imgUrl) {
         this.cakeId = cake.getCakeId();
-        this.img = cake.getUrl();
+        this.img = imgUrl;
         this.storeId = cake.getStore().getStoreId();
         this.storeName = cake.getStore().getName();
         this.likeCnt = cake.getLikeCnt();

--- a/src/main/java/com/project/makecake/service/CakeService.java
+++ b/src/main/java/com/project/makecake/service/CakeService.java
@@ -86,6 +86,7 @@ public class CakeService {
             CakeResponseDto responseDto = CakeResponseDto.builder()
                     .cake(cake)
                     .myLike(myLike)
+                    .imgUrl(cake.getThumbnailUrl())
                     .build();
             responseDtoList.add(responseDto);
         }
@@ -120,6 +121,7 @@ public class CakeService {
         return CakeResponseDto.builder()
                 .cake(foundCake)
                 .myLike(myLike)
+                .imgUrl(foundCake.getUrl())
                 .build();
     }
 


### PR DESCRIPTION
이미지 로딩 속도를 위해 리스트로 볼 때는 썸네일 이미지, 상세보기는 원본 이미지로 전송되도록 변경